### PR TITLE
RMET-3394 OSBarcodeLib-Android - Add serializable annotation to avoid problems with code obfuscation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## [1.1.2]
+
+### 21-05-2024
+- Fix: Adds serializable annotation to avoid problems with code obfuscation (https://outsystemsrd.atlassian.net/browse/RMET-3394).
+
 ## [1.1.1]
 
 ### 30-04-2024

--- a/build.gradle
+++ b/build.gradle
@@ -121,6 +121,7 @@ dependencies {
     implementation 'androidx.camera:camera-core:1.0.0'
     implementation 'com.google.zxing:core:3.4.1'
     implementation 'com.google.mlkit:barcode-scanning:17.2.0'
+    implementation 'com.google.code.gson:gson:2.10.1'
 
     testImplementation "org.mockito:mockito-core:4.3.0"
     testImplementation 'org.mockito:mockito-inline:4.3.0'

--- a/pom.xml
+++ b/pom.xml
@@ -7,5 +7,5 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.outsystems</groupId>
     <artifactId>osbarcode-android</artifactId>
-    <version>1.1.1.1</version>
+    <version>1.1.2</version>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -7,5 +7,5 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.outsystems</groupId>
     <artifactId>osbarcode-android</artifactId>
-    <version>1.1.1</version>
+    <version>1.1.1.1</version>
 </project>

--- a/src/main/kotlin/com/outsystems/plugins/barcode/model/OSBARCScanParameters.kt
+++ b/src/main/kotlin/com/outsystems/plugins/barcode/model/OSBARCScanParameters.kt
@@ -1,16 +1,17 @@
 package com.outsystems.plugins.barcode.model
 
 import java.io.Serializable
+import com.google.gson.annotations.SerializedName
 
 /**
  * Data class that represents the object with the scan parameters.
  */
 data class OSBARCScanParameters(
-    val scanInstructions: String?,
-    val cameraDirection: Int?,
-    val scanOrientation: Int?,
-    val scanButton: Boolean,
-    val scanText: String,
-    val hint: Int?,
-    val androidScanningLibrary: String?
+    @SerializedName("scanInstructions") val scanInstructions: String?,
+    @SerializedName("cameraDirection") val cameraDirection: Int?,
+    @SerializedName("scanOrientation") val scanOrientation: Int?,
+    @SerializedName("scanButton") val scanButton: Boolean,
+    @SerializedName("scanText") val scanText: String,
+    @SerializedName("hint") val hint: Int?,
+    @SerializedName("androidScanningLibrary") val androidScanningLibrary: String?
 ) : Serializable


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- Adds `@SerializedName` annotation to the `OSBARCScanParameters` fields to avoid problems with code obfuscation (AppShield).

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

References: https://outsystemsrd.atlassian.net/browse/RMET-3394

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

Tested with Android 14 (Pixel 7), using a MABS 10 build: https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=ef2a0b6346fd7566d4d4f6f4c395dc16b57edaf9

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
