### PR TITLE
App Crash Due to High RAM Consumption When Using ML Kit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.1'
+        classpath 'com.android.tools.build:gradle:8.1.4'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jacoco:org.jacoco.core:$jacocoVersion"
     }

--- a/src/main/kotlin/com/outsystems/plugins/barcode/controller/helper/OSBARCMLKitHelper.kt
+++ b/src/main/kotlin/com/outsystems/plugins/barcode/controller/helper/OSBARCMLKitHelper.kt
@@ -13,10 +13,7 @@ import com.google.mlkit.vision.common.InputImage
  * to scan an image using the ML Kit library.
  * It encapsulates all the code related with the ML Kit library.
  */
-class OSBARCMLKitHelper(private val delayMillis: Long? = 500L): OSBARCMLKitHelperInterface {
-
-    private var lastAnalyzedTimestamp = 0L
-
+class OSBARCMLKitHelper: OSBARCMLKitHelperInterface {
     companion object {
         private const val LOG_TAG = "OSBARCMLKitHelper"
     }
@@ -34,32 +31,22 @@ class OSBARCMLKitHelper(private val delayMillis: Long? = 500L): OSBARCMLKitHelpe
         onSuccess: (MutableList<Barcode>) -> Unit,
         onError: () -> Unit
     ) {
-        val currentTimestamp = System.currentTimeMillis()
-
-        // Use the delayMillis value, defaulting to 500 milliseconds if it is null
-        val effectiveDelayMillis = delayMillis ?: 500L
-
-        // Only analyze the image if the desired delay has passed
-        if (currentTimestamp - lastAnalyzedTimestamp >= effectiveDelayMillis) {
-            val options = BarcodeScannerOptions.Builder()
-                .enableAllPotentialBarcodes()
-                .build()
-            val scanner = BarcodeScanning.getClient(options)
-            val image = InputImage.fromBitmap(
-                imageBitmap,
-                imageProxy.imageInfo.rotationDegrees
-            )
-            scanner.process(image)
-                .addOnSuccessListener { barcodes ->
-                    onSuccess(barcodes)
-                }
-                .addOnFailureListener { e ->
-                    e.message?.let { Log.e(LOG_TAG, it) }
-                    onError()
-                }
-            // Update the timestamp of the last analyzed frame
-            lastAnalyzedTimestamp = currentTimestamp
-        }
+        val options = BarcodeScannerOptions.Builder()
+            .enableAllPotentialBarcodes()
+            .build()
+        val scanner = BarcodeScanning.getClient(options)
+        val image = InputImage.fromBitmap(
+            imageBitmap,
+            imageProxy.imageInfo.rotationDegrees
+        )
+        scanner.process(image)
+            .addOnSuccessListener { barcodes ->
+                onSuccess(barcodes)
+            }
+            .addOnFailureListener { e ->
+                e.message?.let { Log.e(LOG_TAG, it) }
+                onError()
+            }
     }
 
 }

--- a/src/main/kotlin/com/outsystems/plugins/barcode/model/OSBARCScanParameters.kt
+++ b/src/main/kotlin/com/outsystems/plugins/barcode/model/OSBARCScanParameters.kt
@@ -13,5 +13,6 @@ data class OSBARCScanParameters(
     @SerializedName("scanButton") val scanButton: Boolean,
     @SerializedName("scanText") val scanText: String,
     @SerializedName("hint") val hint: Int?,
-    @SerializedName("androidScanningLibrary") val androidScanningLibrary: String?
+    @SerializedName("androidScanningLibrary") val androidScanningLibrary: String?,
+    @SerializedName("scanInterval") val scanInterval: Long?
 ) : Serializable

--- a/src/main/kotlin/com/outsystems/plugins/barcode/view/OSBARCScannerActivity.kt
+++ b/src/main/kotlin/com/outsystems/plugins/barcode/view/OSBARCScannerActivity.kt
@@ -178,7 +178,7 @@ class OSBARCScannerActivity : ComponentActivity() {
             OSBARCScanLibraryFactory.createScanLibraryWrapper(
                 parameters.androidScanningLibrary ?: "",
                 OSBARCZXingHelper(),
-                OSBARCMLKitHelper(parameters.scanInterval)
+                OSBARCMLKitHelper()
             ),
             OSBARCImageHelper(),
             { result ->
@@ -186,7 +186,8 @@ class OSBARCScannerActivity : ComponentActivity() {
             },
             {
                 processReadError(it)
-            }
+            },
+            parameters.scanInterval
         )
 
         setContent {

--- a/src/main/kotlin/com/outsystems/plugins/barcode/view/OSBARCScannerActivity.kt
+++ b/src/main/kotlin/com/outsystems/plugins/barcode/view/OSBARCScannerActivity.kt
@@ -178,7 +178,7 @@ class OSBARCScannerActivity : ComponentActivity() {
             OSBARCScanLibraryFactory.createScanLibraryWrapper(
                 parameters.androidScanningLibrary ?: "",
                 OSBARCZXingHelper(),
-                OSBARCMLKitHelper()
+                OSBARCMLKitHelper(parameters.scanInterval)
             ),
             OSBARCImageHelper(),
             { result ->


### PR DESCRIPTION
I have introduced a new option parameter in the 'OSBARCScanParameters' class called 'scanInterval.' This parameter adds a delay when performing image decoding in the 'OSBARCMLKitHelper' class. By adding a small delay, we can resolve the high RAM consumption issue, as memory usage increases exponentially when decoding is performed by ML Kit. Adding a slight delay of about 500 milliseconds does not affect scanning efficiency but optimizes RAM usage.

Issue
https://github.com/OutSystems/OSBarcodeLib-Android/issues/30