### PR TITLE
RMET-3379 OSBarcodeLib - Fix UI bug when layout is portrait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## [1.1.3]
+
+### 22-08-2024
+- Fix: Avoid UI bug on background when layout is portrait (https://outsystemsrd.atlassian.net/browse/RMET-3379).
+
 ## [1.1.2]
 
 ### 21-05-2024

--- a/pom.xml
+++ b/pom.xml
@@ -7,5 +7,5 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.outsystems</groupId>
     <artifactId>osbarcode-android</artifactId>
-    <version>1.1.3-dev</version>
+    <version>1.1.3</version>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -7,5 +7,5 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.outsystems</groupId>
     <artifactId>osbarcode-android</artifactId>
-    <version>1.1.3-dev2</version>
+    <version>1.1.3</version>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -7,5 +7,5 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.outsystems</groupId>
     <artifactId>osbarcode-android</artifactId>
-    <version>1.1.3</version>
+    <version>1.1.3-dev2</version>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -7,5 +7,5 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.outsystems</groupId>
     <artifactId>osbarcode-android</artifactId>
-    <version>1.1.2</version>
+    <version>1.1.3-dev</version>
 </project>

--- a/src/main/kotlin/com/outsystems/plugins/barcode/view/OSBARCScannerActivity.kt
+++ b/src/main/kotlin/com/outsystems/plugins/barcode/view/OSBARCScannerActivity.kt
@@ -523,7 +523,8 @@ class OSBARCScannerActivity : ComponentActivity() {
                 ScanInstructions(
                     modifier = Modifier
                         .fillMaxWidth(),
-                    parameters
+                    parameters,
+                    true
                 )
 
                 ScanScreenAim(screenHeight, borderPadding, borderPadding, isPhone, true)
@@ -618,7 +619,8 @@ class OSBARCScannerActivity : ComponentActivity() {
                             top = borderPadding,
                             bottom = if (isPhone) NoPadding else textToRectPadding
                         ),
-                    parameters
+                    parameters,
+                    false
                 )
 
                 ScanScreenAim(screenHeight, NoPadding, borderPadding, isPhone, isPortrait)
@@ -761,16 +763,17 @@ class OSBARCScannerActivity : ComponentActivity() {
      * This component will only be rendered if scan parameters instructs so.
      * @param modifier the custom modifier for the whole view
      * @param parameters the scan parameters
+     * @param isPortrait identifies if the layout is portrait or landscape
      */
     @Composable
-    fun ScanInstructions(modifier: Modifier, parameters: OSBARCScanParameters) {
-        if (!parameters.scanInstructions.isNullOrEmpty()) {
+    fun ScanInstructions(modifier: Modifier, parameters: OSBARCScanParameters, isPortrait: Boolean) {
+        if (!parameters.scanInstructions.isNullOrBlank() || isPortrait) {
             Box(
                 modifier = Modifier
                     .background(ScannerBackgroundBlack)
             ) {
                 Text(
-                    text = parameters.scanInstructions,
+                    text = parameters.scanInstructions ?: "",
                     modifier = modifier,
                     color = ScanInstructionsWhite,
                     textAlign = TextAlign.Center

--- a/src/main/kotlin/com/outsystems/plugins/barcode/view/OSBARCScannerActivity.kt
+++ b/src/main/kotlin/com/outsystems/plugins/barcode/view/OSBARCScannerActivity.kt
@@ -767,7 +767,7 @@ class OSBARCScannerActivity : ComponentActivity() {
      */
     @Composable
     fun ScanInstructions(modifier: Modifier, parameters: OSBARCScanParameters, isPortrait: Boolean) {
-        if (!parameters.scanInstructions.isNullOrBlank() || isPortrait) {
+        if (isPortrait || !parameters.scanInstructions.isNullOrBlank()) {
             Box(
                 modifier = Modifier
                     .background(ScannerBackgroundBlack)

--- a/src/main/kotlin/com/outsystems/plugins/barcode/view/OSBARCScannerActivity.kt
+++ b/src/main/kotlin/com/outsystems/plugins/barcode/view/OSBARCScannerActivity.kt
@@ -520,11 +520,17 @@ class OSBARCScannerActivity : ComponentActivity() {
                 verticalArrangement = Arrangement.Center
             ) {
 
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .weight(1f, fill = true)
+                        .background(ScannerBackgroundBlack)
+                )
+
                 ScanInstructions(
                     modifier = Modifier
                         .fillMaxWidth(),
-                    parameters,
-                    true
+                    parameters
                 )
 
                 ScanScreenAim(screenHeight, borderPadding, borderPadding, isPhone, true)
@@ -619,8 +625,7 @@ class OSBARCScannerActivity : ComponentActivity() {
                             top = borderPadding,
                             bottom = if (isPhone) NoPadding else textToRectPadding
                         ),
-                    parameters,
-                    false
+                    parameters
                 )
 
                 ScanScreenAim(screenHeight, NoPadding, borderPadding, isPhone, isPortrait)
@@ -763,17 +768,16 @@ class OSBARCScannerActivity : ComponentActivity() {
      * This component will only be rendered if scan parameters instructs so.
      * @param modifier the custom modifier for the whole view
      * @param parameters the scan parameters
-     * @param isPortrait identifies if the layout is portrait or landscape
      */
     @Composable
-    fun ScanInstructions(modifier: Modifier, parameters: OSBARCScanParameters, isPortrait: Boolean) {
-        if (isPortrait || !parameters.scanInstructions.isNullOrBlank()) {
+    fun ScanInstructions(modifier: Modifier, parameters: OSBARCScanParameters) {
+        if (!parameters.scanInstructions.isNullOrBlank()) {
             Box(
                 modifier = Modifier
                     .background(ScannerBackgroundBlack)
             ) {
                 Text(
-                    text = parameters.scanInstructions ?: "",
+                    text = parameters.scanInstructions,
                     modifier = modifier,
                     color = ScanInstructionsWhite,
                     textAlign = TextAlign.Center


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- Fixes a UI bug where the darker background was incorrectly drawn, when the layout was portrait.
- It also replaces `isNullOrEmpty` with `isNullOrBlank` to avoid creating the text with `scanInstructions` is `"   "` for example.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

References: https://outsystemsrd.atlassian.net/browse/RMET-3379

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

Tested on Android 15 (Pixel 7), Android 13 (Samsung A51), Android 12 (Pixel 3XL), and on a Pixel C Tablet (Android 14) emulator.

MABS 10 build: https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=4b1ae98968e0acdc48d2060ec50187696ecf0071

## Screenshots (if appropriate)

![1000000430](https://github.com/user-attachments/assets/0ba1b20c-28eb-429a-b63f-d5f084c43c05)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
