### PR TITLE
RMET-3682 ::: Make Scanner View Wider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## [1.1.4]
+
+### 08-10-2024
+- Fix: Make Scanner view wider on landscape and on tablets (https://outsystemsrd.atlassian.net/browse/RMET-3682).
+
 ## [1.1.3]
 
 ### 22-08-2024

--- a/pom.xml
+++ b/pom.xml
@@ -7,5 +7,5 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.outsystems</groupId>
     <artifactId>osbarcode-android</artifactId>
-    <version>1.1.3</version>
+    <version>1.1.4</version>
 </project>

--- a/src/main/kotlin/com/outsystems/plugins/barcode/view/OSBARCScannerActivity.kt
+++ b/src/main/kotlin/com/outsystems/plugins/barcode/view/OSBARCScannerActivity.kt
@@ -45,6 +45,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -76,8 +77,10 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.drawscope.clipPath
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
@@ -394,15 +397,21 @@ class OSBARCScannerActivity : ComponentActivity() {
                 var rectHeight: Float
 
                 if (isPhone) { // for phones
-                    rectWidth = canvasWidth - (horizontalPadding.toPx() * 2) - (ScannerAimRectCornerPadding.toPx() * 2)
-                    rectHeight = canvasHeight - (verticalPadding.toPx() * 2) - (ScannerAimRectCornerPadding.toPx() * 2)
-                } else { // for tablets
                     if (isPortrait) {
-                        rectWidth = (canvasWidth) - (horizontalPadding.toPx() * 2) - (ScannerAimRectCornerPadding.toPx() * 2)
-                        rectHeight = rectWidth
-                    } else {
                         rectWidth = canvasWidth - (horizontalPadding.toPx() * 2) - (ScannerAimRectCornerPadding.toPx() * 2)
-                        rectHeight = canvasHeight - (ScannerAimRectCornerPadding.toPx() * 2)
+                        rectHeight = canvasHeight - (verticalPadding.toPx() * 2) - (ScannerAimRectCornerPadding.toPx() * 2)
+                    } else {
+                        // For phone landscape, use the full width
+                        rectWidth = canvasWidth - (ScannerAimRectCornerPadding.toPx() * 2)
+                        rectHeight = canvasHeight - (verticalPadding.toPx() * 2) - (ScannerAimRectCornerPadding.toPx() * 2)
+                    }
+                } else { // for tablets
+                    // For tablets, use the full width in both orientations
+                    rectWidth = canvasWidth - (ScannerAimRectCornerPadding.toPx() * 2)
+                    rectHeight = if (isPortrait) {
+                        rectWidth // Make it square in portrait
+                    } else {
+                        canvasHeight - (ScannerAimRectCornerPadding.toPx() * 2)
                     }
                 }
 
@@ -591,6 +600,9 @@ class OSBARCScannerActivity : ComponentActivity() {
                               textToRectPadding: Dp,
                               isPhone: Boolean,
                               isPortrait: Boolean) {
+        var rightButtonsWidth by remember { mutableStateOf(0.dp) }
+        val density = LocalDensity.current
+
         Row(
             modifier = Modifier
                 .fillMaxSize(),
@@ -600,14 +612,14 @@ class OSBARCScannerActivity : ComponentActivity() {
             Box(
                 modifier = Modifier
                     .fillMaxHeight()
-                    .weight(1f, fill = true)
+                    .width(rightButtonsWidth)
                     .background(ScannerBackgroundBlack)
             )
 
             Column(
                 modifier = Modifier
                     .fillMaxHeight()
-                    .weight(2f, fill = true),
+                    .weight(1f),
                 verticalArrangement = Arrangement.Center
             ) {
 
@@ -636,13 +648,14 @@ class OSBARCScannerActivity : ComponentActivity() {
                         .weight(1f, fill = true)
                         .background(ScannerBackgroundBlack)
                 )
-
             }
 
             Box(
                 modifier = Modifier
                     .fillMaxHeight()
-                    .weight(1f, fill = true)
+                    .onGloballyPositioned { coordinates ->
+                        rightButtonsWidth = with(density) { coordinates.size.width.toDp() }
+                    }
                     .background(ScannerBackgroundBlack)
             ) {
 

--- a/src/main/kotlin/com/outsystems/plugins/barcode/view/OSBARCScannerActivity.kt
+++ b/src/main/kotlin/com/outsystems/plugins/barcode/view/OSBARCScannerActivity.kt
@@ -608,14 +608,15 @@ class OSBARCScannerActivity : ComponentActivity() {
                 .fillMaxSize(),
             horizontalArrangement = Arrangement.SpaceBetween
         ) {
-
-            Box(
+            // Left spacer to maintain horizontal conformance
+            Spacer(
                 modifier = Modifier
                     .fillMaxHeight()
                     .width(rightButtonsWidth)
                     .background(ScannerBackgroundBlack)
             )
 
+            // Center column with scanning area
             Column(
                 modifier = Modifier
                     .fillMaxHeight()
@@ -650,6 +651,7 @@ class OSBARCScannerActivity : ComponentActivity() {
                 )
             }
 
+            // Right column with buttons
             Box(
                 modifier = Modifier
                     .fillMaxHeight()
@@ -667,7 +669,7 @@ class OSBARCScannerActivity : ComponentActivity() {
 
                 Column(
                     modifier = Modifier
-                        .padding(end = ScannerBorderPadding)
+                        .padding(start = 24.dp, end = ScannerBorderPadding)
                         .align(Alignment.CenterEnd),
                     verticalArrangement = Arrangement.Center,
                     horizontalAlignment = Alignment.End

--- a/src/main/kotlin/com/outsystems/plugins/barcode/view/OSBARCScannerActivity.kt
+++ b/src/main/kotlin/com/outsystems/plugins/barcode/view/OSBARCScannerActivity.kt
@@ -393,21 +393,14 @@ class OSBARCScannerActivity : ComponentActivity() {
 
                 // rectangle size is determined by removing the padding from the border of the screen
                 // and the padding to the corners of the rectangle
-                var rectWidth: Float
-                var rectHeight: Float
+                var rectWidth: Float = canvasWidth - (ScannerAimRectCornerPadding.toPx() * 2)
+                var rectHeight: Float = canvasHeight - (verticalPadding.toPx() * 2) - (ScannerAimRectCornerPadding.toPx() * 2)
 
                 if (isPhone) { // for phones
                     if (isPortrait) {
                         rectWidth = canvasWidth - (horizontalPadding.toPx() * 2) - (ScannerAimRectCornerPadding.toPx() * 2)
-                        rectHeight = canvasHeight - (verticalPadding.toPx() * 2) - (ScannerAimRectCornerPadding.toPx() * 2)
-                    } else {
-                        // For phone landscape, use the full width
-                        rectWidth = canvasWidth - (ScannerAimRectCornerPadding.toPx() * 2)
-                        rectHeight = canvasHeight - (verticalPadding.toPx() * 2) - (ScannerAimRectCornerPadding.toPx() * 2)
                     }
                 } else { // for tablets
-                    // For tablets, ensure the rectangle fits within the canvas
-                    rectWidth = canvasWidth - (ScannerAimRectCornerPadding.toPx() * 2)
                     rectHeight = minOf(rectWidth, canvasHeight - (ScannerAimRectCornerPadding.toPx() * 2))
                 }
 

--- a/src/main/kotlin/com/outsystems/plugins/barcode/view/OSBARCScannerActivity.kt
+++ b/src/main/kotlin/com/outsystems/plugins/barcode/view/OSBARCScannerActivity.kt
@@ -406,13 +406,9 @@ class OSBARCScannerActivity : ComponentActivity() {
                         rectHeight = canvasHeight - (verticalPadding.toPx() * 2) - (ScannerAimRectCornerPadding.toPx() * 2)
                     }
                 } else { // for tablets
-                    // For tablets, use the full width in both orientations
+                    // For tablets, ensure the rectangle fits within the canvas
                     rectWidth = canvasWidth - (ScannerAimRectCornerPadding.toPx() * 2)
-                    rectHeight = if (isPortrait) {
-                        rectWidth // Make it square in portrait
-                    } else {
-                        canvasHeight - (ScannerAimRectCornerPadding.toPx() * 2)
-                    }
+                    rectHeight = minOf(rectWidth, canvasHeight - (ScannerAimRectCornerPadding.toPx() * 2))
                 }
 
                 val rectLeft = (canvasWidth - rectWidth) / 2

--- a/src/main/kotlin/com/outsystems/plugins/barcode/view/OSBARCScannerActivity.kt
+++ b/src/main/kotlin/com/outsystems/plugins/barcode/view/OSBARCScannerActivity.kt
@@ -672,7 +672,7 @@ class OSBARCScannerActivity : ComponentActivity() {
 
                 Column(
                     modifier = Modifier
-                        .padding(start = 24.dp, end = ScannerBorderPadding)
+                        .padding(start = 12.dp, end = ScannerBorderPadding)
                         .align(Alignment.CenterEnd),
                     verticalArrangement = Arrangement.Center,
                     horizontalAlignment = Alignment.End

--- a/src/main/kotlin/com/outsystems/plugins/barcode/view/OSBARCScannerActivity.kt
+++ b/src/main/kotlin/com/outsystems/plugins/barcode/view/OSBARCScannerActivity.kt
@@ -432,10 +432,13 @@ class OSBARCScannerActivity : ComponentActivity() {
                     drawRect(color = ScannerBackgroundBlack)
                 }
 
-                val aimTop = rectTop - ScannerAimRectCornerPadding.toPx()
-                val aimLeft = rectLeft - ScannerAimRectCornerPadding.toPx()
-                val aimRight = aimLeft + rectWidth + (ScannerAimRectCornerPadding * 2).toPx()
-                val aimBottom = aimTop + rectHeight + (ScannerAimRectCornerPadding * 2).toPx()
+                val strokeWidth = ScannerAimStrokeWidth
+                val halfStroke = strokeWidth / 2
+
+                val aimTop = rectTop - ScannerAimRectCornerPadding.toPx() + halfStroke
+                val aimLeft = rectLeft - ScannerAimRectCornerPadding.toPx() + halfStroke
+                val aimRight = aimLeft + rectWidth + (ScannerAimRectCornerPadding * 2).toPx() - strokeWidth
+                val aimBottom = aimTop + rectHeight + (ScannerAimRectCornerPadding * 2).toPx() - strokeWidth
                 val aimLength = ScannerAimCornerLength.toPx()
 
                 val aimPath = Path()
@@ -475,7 +478,7 @@ class OSBARCScannerActivity : ComponentActivity() {
                     Point(aimRight - radius, aimTop),
                     Point(aimRight - aimLength, aimTop)
                 )
-                drawPath(aimPath, color = ScanAimWhite, style = Stroke(width = ScannerAimStrokeWidth))
+                drawPath(aimPath, color = ScanAimWhite, style = Stroke(width = strokeWidth))
             }
         )
     }


### PR DESCRIPTION
## Description
Improved scanning area width for large barcodes by dynamically calculating the right button area width and adjusting the scanner view accordingly for phones in landscape and tablet layouts in both portrait and landscape orientations.

## Context
https://outsystemsrd.atlassian.net/browse/RMET-3682

## Type of changes
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Tests
Tested on Pixel 8 Pro
Tested on Pixel Tablet Emulator

## Screenshots
**BEFORE**
![Screenshot_20241009-160107](https://github.com/user-attachments/assets/578c6cd0-4df7-4d62-a2c1-fc250bf29d85)


**AFTER**
![Screenshot_20241009-160248](https://github.com/user-attachments/assets/a7a15859-8115-4ab5-8d36-c128e0a49b1d)



## Checklist
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
