### PR TITLE
RMET-3597 ::: Android 15 - Support edge-to-edge and drop Configuration for layout size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## [Unreleased]
+
+### 05-11-2024
+- Fix: Edge-to-edge support on Android 15 (https://outsystemsrd.atlassian.net/browse/RMET-3597)
+
 ## [1.1.4]
 
 ### 08-10-2024

--- a/build.gradle
+++ b/build.gradle
@@ -108,6 +108,7 @@ dependencies {
     implementation "androidx.activity:activity-compose:1.4.0"
     implementation 'androidx.compose.material3:material3:1.0.0'
     implementation 'androidx.compose.material3:material3-window-size-class:1.0.0'
+    implementation 'androidx.window:window:1.3.0'
 
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'

--- a/pom.xml
+++ b/pom.xml
@@ -7,5 +7,5 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.outsystems</groupId>
     <artifactId>osbarcode-android</artifactId>
-    <version>1.1.4</version>
+    <version>1.1.5-dev</version>
 </project>

--- a/src/main/kotlin/com/outsystems/plugins/barcode/view/OSBARCScannerActivity.kt
+++ b/src/main/kotlin/com/outsystems/plugins/barcode/view/OSBARCScannerActivity.kt
@@ -286,7 +286,6 @@ class OSBARCScannerActivity : ComponentActivity() {
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .safeDrawingPadding()
         ) {
             AndroidView(
                 factory = { context ->
@@ -505,7 +504,8 @@ class OSBARCScannerActivity : ComponentActivity() {
                 modifier = Modifier
                     .fillMaxWidth()
                     .background(ScannerBackgroundBlack)
-                    .weight(1f, fill = true),
+                    .weight(1f, fill = true)
+                    .safeDrawingPadding(),
             ) {
                 CloseButton(
                     modifier = Modifier
@@ -541,7 +541,8 @@ class OSBARCScannerActivity : ComponentActivity() {
                 modifier = Modifier
                     .fillMaxWidth()
                     .background(ScannerBackgroundBlack)
-                    .weight(1f, fill = true),
+                    .weight(1f, fill = true)
+                    .safeDrawingPadding(),
             ) {
                 val showTorch = camera.cameraInfo.hasFlashUnit()
                 val showScan = parameters.scanButton
@@ -651,6 +652,7 @@ class OSBARCScannerActivity : ComponentActivity() {
                         rightButtonsWidth = with(density) { coordinates.size.width.toDp() }
                     }
                     .background(ScannerBackgroundBlack)
+                    .safeDrawingPadding()
             ) {
 
                 CloseButton(

--- a/src/main/kotlin/com/outsystems/plugins/barcode/view/OSBARCScannerActivity.kt
+++ b/src/main/kotlin/com/outsystems/plugins/barcode/view/OSBARCScannerActivity.kt
@@ -77,6 +77,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.drawscope.clipPath
+import androidx.compose.ui.graphics.toComposeRect
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
@@ -89,6 +90,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.content.ContextCompat
 import androidx.core.view.WindowCompat
+import androidx.window.layout.WindowMetricsCalculator
 import com.outsystems.plugins.barcode.R
 import com.outsystems.plugins.barcode.controller.OSBARCBarcodeAnalyzer
 import com.outsystems.plugins.barcode.controller.OSBARCScanLibraryFactory
@@ -337,8 +339,13 @@ class OSBARCScannerActivity : ComponentActivity() {
     fun ScanScreenUI(parameters: OSBARCScanParameters, windowSizeClass: WindowSizeClass) {
         // actual UI on top of the camera stream
         val configuration = LocalConfiguration.current
-        screenHeight = configuration.screenHeightDp.dp
-        screenWidth = configuration.screenWidthDp.dp
+        val windowMetrics =
+            WindowMetricsCalculator.getOrCreate().computeCurrentWindowMetrics(this)
+        val rect = windowMetrics.bounds.toComposeRect()
+        with(LocalDensity.current) {
+            screenHeight = rect.height.toDp()
+            screenWidth = rect.width.toDp()
+        }
 
         val isPortrait = configuration.orientation == Configuration.ORIENTATION_PORTRAIT
 


### PR DESCRIPTION
## Description

- Properly support edge-to-edge on Android 15 devices (with targetSdk=35) by moving the usage of `safeDrawingPadding()` further down the Compose hierarchy
- Stop using `Configuration` class to calculate layout size - Replacing with recommended way via `WindowMetrics`. 
    - Still using `Configuration` for the determining the device's orientation. The only difference in Android 15 is that the orientation may differ for near-square-shaped devices (where the window insets make the width larger than height or vice-versa). Since there is no newer API to use, and due to the limited devices that this affects, left it as-is.

## Context

https://outsystemsrd.atlassian.net/browse/RMET-3597

https://outsystemsrd.atlassian.net/wiki/spaces/RDME/pages/4426137659/iOS+18+Android+15+Assessment

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [X] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [X] Android
- [ ] iOS
- [ ] JavaScript

## Tests

Tested on Android 15 devices with target 35 Barcode Sample app to confirm that the barcode scanning screen is now properly edge-to-edge. 

## Screenshots (if appropriate)

Note that the frame size changed slightly because the measurement now includes the window insets.

| Type           | Before         | After           |
| ----------- | ----------- | ----------- |
| Pixel Android 15 portrait      | ![before_pixel_android15_portrait](https://github.com/user-attachments/assets/24ed556b-76ac-4742-a3e1-823c40c5a733) | ![after_pixel_android15_portrait](https://github.com/user-attachments/assets/9d493d6b-b5a2-4281-a066-f681c44b20ef) |
| Pixel Android 15 landscape   | ![before_pixel_android15_landscape1](https://github.com/user-attachments/assets/b5ab5671-18e1-4c12-b3b2-1320de568480) | ![after_pixel_android15_landscape1](https://github.com/user-attachments/assets/f1032367-8f1b-42a9-907b-26c3b78b4d9f) |


## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [ ] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
- [ ] Documentation has been updated accordingly
