### PR TITLE
RMET-3602 ::: Updated libs for 16KB page alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
+### 08-11-2024
+- Fix: Update libraries for supporting 16KB page size (https://outsystemsrd.atlassian.net/browse/RMET-3602)
+
 ### 05-11-2024
 - Fix: Edge-to-edge support on Android 15 (https://outsystemsrd.atlassian.net/browse/RMET-3597)
 

--- a/build.gradle
+++ b/build.gradle
@@ -116,12 +116,12 @@ dependencies {
     androidTestImplementation "androidx.compose.ui:ui-test-junit4:1.0.5"
     debugImplementation "androidx.compose.ui:ui-tooling:1.0.5"
 
-    implementation "androidx.camera:camera-camera2:1.3.0"
-    implementation 'androidx.camera:camera-lifecycle:1.0.2'
-    implementation 'androidx.camera:camera-view:1.0.0-alpha31'
-    implementation 'androidx.camera:camera-core:1.0.0'
+    implementation "androidx.camera:camera-camera2:1.4.0"
+    implementation 'androidx.camera:camera-lifecycle:1.4.0'
+    implementation 'androidx.camera:camera-view:1.4.0'
+    implementation 'androidx.camera:camera-core:1.4.0'
     implementation 'com.google.zxing:core:3.4.1'
-    implementation 'com.google.mlkit:barcode-scanning:17.2.0'
+    implementation 'com.google.mlkit:barcode-scanning:17.3.0'
     implementation 'com.google.code.gson:gson:2.10.1'
 
     testImplementation "org.mockito:mockito-core:4.3.0"

--- a/pom.xml
+++ b/pom.xml
@@ -7,5 +7,5 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.outsystems</groupId>
     <artifactId>osbarcode-android</artifactId>
-    <version>1.1.5-dev</version>
+    <version>1.1.5-dev2</version>
 </project>


### PR DESCRIPTION
## Description

Update mlkit and camera libraries to latest version, that have their shared libraries (.so files) 16KB-aligned.

The actual fix is in https://github.com/OutSystems/cordova-outsystems-barcode/pull/33 - this is more to make sure the dependency versions are aligned.

## Context

- https://outsystemsrd.atlassian.net/browse/RMET-3602
- https://outsystemsrd.atlassian.net/wiki/spaces/RDME/pages/4426137659/iOS+18+Android+15+Assessment
- https://developer.android.com/guide/practices/page-sizes

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [X] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [X] Android
- [ ] iOS
- [ ] JavaScript

## Tests

Refer to https://github.com/OutSystems/cordova-outsystems-barcode/pull/33

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [ ] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
