### PR TITLE
fix: Publishing Migration To Central Portal

### DIFF
--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -22,8 +22,8 @@ jobs:
       - name: Make local props
         run: |
           cat << EOF > "local.properties"
-          ossrhUsername=${{ secrets.ANDROID_OSSRH_USERNAME }}
-          ossrhPassword=${{ secrets.ANDROID_OSSRH_PASSWORD }}
+          centralTokenUsername=${{ secrets.ANDROID_CENTRAL_USERNAME }}
+          centralTokenPassword=${{ secrets.ANDROID_CENTRAL_PASSWORD }}
           sonatypeStagingProfileId=${{ secrets.ANDROID_SONATYPE_STAGING_PROFILE_ID }}
           signing.keyId=${{ secrets.ANDROID_SIGNING_KEY_ID }}
           signing.password=${{ secrets.ANDROID_SIGNING_PASSWORD }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
+### 2025-06-24
+
+- Migrate publishing from OSSRH to Central Portal.
+
 ### 28-01-2025
 - Add `publish-android` workflow to publish library under `io.ionic.libs` in Maven (https://outsystemsrd.atlassian.net/browse/RMET-3983)
 

--- a/scripts/publish-android.sh
+++ b/scripts/publish-android.sh
@@ -30,7 +30,7 @@ else
     if grep --quiet "BUILD SUCCESSFUL" $LOG_OUTPUT; then
         printf %"s\n" "Success: Published to MavenCentral."
     else
-        printf %"s\n" "Error publishing, check $LOG_OUTPUT for more info! Manually review and release from the Sonatype Repository Manager may be necessary https://s01.oss.sonatype.org/"
+        printf %"s\n" "Error publishing, check $LOG_OUTPUT for more info! Manually review and release from the Central Portal may be necessary https://central.sonatype.com/publishing/deployments/"
         cat $LOG_OUTPUT
         exit 1
     fi

--- a/scripts/publish-root.gradle
+++ b/scripts/publish-root.gradle
@@ -2,8 +2,8 @@
 ext["signing.keyId"] = ''
 ext["signing.key"] = ''
 ext["signing.password"] = ''
-ext["ossrhUsername"] = ''
-ext["ossrhPassword"] = ''
+ext["centralTokenUsername"] = ''
+ext["centralTokenPassword"] = ''
 ext["sonatypeStagingProfileId"] = ''
 
 File secretPropsFile = file('./local.properties')
@@ -14,8 +14,8 @@ if (secretPropsFile.exists()) {
     p.each { name, value -> ext[name] = value }
 } else {
     // Use system environment variables
-    ext["ossrhUsername"] = System.getenv('ANDROID_OSSRH_USERNAME')
-    ext["ossrhPassword"] = System.getenv('ANDROID_OSSRH_PASSWORD')
+    ext["centralTokenUsername"] = System.getenv('ANDROID_CENTRAL_USERNAME')
+    ext["centralTokenPassword"] = System.getenv('ANDROID_CENTRAL_PASSWORD')
     ext["sonatypeStagingProfileId"] = System.getenv('ANDROID_SONATYPE_STAGING_PROFILE_ID')
     ext["signing.keyId"] = System.getenv('ANDROID_SIGNING_KEY_ID')
     ext["signing.key"] = System.getenv('ANDROID_SIGNING_KEY')
@@ -27,10 +27,10 @@ nexusPublishing {
     repositories {
         sonatype {
             stagingProfileId = sonatypeStagingProfileId
-            username = ossrhUsername
-            password = ossrhPassword
-            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
-            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+            username = centralTokenUsername
+            password = centralTokenPassword
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
         }
     }
     repositoryDescription = 'OSBarcode Android Lib v' + System.getenv('THE_VERSION')


### PR DESCRIPTION
## Description

We currently publish the library in Maven Central through OSSRH, however this needs to be changed due OSSRH being shutdown in after June 30th 2025.

Migration of `io.ionic` namespace to Central Portal has already been done, this PR takes care of updating the publishing logic - which uses a new token that is now accessed in different github secrets.

Relevant References:

- https://central.sonatype.org/faq/what-is-different-between-central-portal-and-legacy-ossrh/
- https://github.com/gradle-nexus/publish-plugin?tab=readme-ov-file#publishing-to-maven-central-via-sonatype-central

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
