### PR TITLE
fix: make MLKit scanner initialization lazy to prevent memory consumption overload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
-## [Unreleased]
+## [1.2.1]
+
+### 20205-08-18
+
+- Make MLKit scanner initialization lazy to prevent memory consumption overload (https://outsystemsrd.atlassian.net/browse/RMET-3481)
 
 ### 2025-06-24
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,5 +7,5 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.ionic.libs</groupId>
     <artifactId>ionbarcode-android</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.1</version>
 </project>

--- a/src/main/kotlin/com/outsystems/plugins/barcode/controller/helper/OSBARCMLKitHelper.kt
+++ b/src/main/kotlin/com/outsystems/plugins/barcode/controller/helper/OSBARCMLKitHelper.kt
@@ -18,6 +18,13 @@ class OSBARCMLKitHelper: OSBARCMLKitHelperInterface {
         private const val LOG_TAG = "OSBARCMLKitHelper"
     }
 
+    private val scanner by lazy {
+        val options = BarcodeScannerOptions.Builder()
+            .enableAllPotentialBarcodes()
+            .build()
+        BarcodeScanning.getClient(options)
+    }
+
     /**
      * Scans an image looking for barcodes, using the ML Kit library.
      * @param imageProxy - ImageProxy object that represents the image to be analyzed.
@@ -31,10 +38,6 @@ class OSBARCMLKitHelper: OSBARCMLKitHelperInterface {
         onSuccess: (MutableList<Barcode>) -> Unit,
         onError: () -> Unit
     ) {
-        val options = BarcodeScannerOptions.Builder()
-            .enableAllPotentialBarcodes()
-            .build()
-        val scanner = BarcodeScanning.getClient(options)
         val image = InputImage.fromBitmap(
             imageBitmap,
             imageProxy.imageInfo.rotationDegrees


### PR DESCRIPTION
## Description
This PR fixes an issue where the MLKit scanner can get backlogged when processing the camera frames and run out of memory

## Context
#30 

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [X] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [X] Android
- [ ] iOS
- [ ] JavaScript

## Tests
Tested on Android 12 Xiaomi device and Android 16 Pixel 8 Pro
