### PR TITLE
fix: Crash due to uninitialized variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+# [2.0.1]
+
+### 2025-10-02
+
+- Fix crash `kotlin.UninitializedPropertyAccessException: lateinit property camera has not been initialized` (https://outsystemsrd.atlassian.net/browse/RMET-4530)
+
 ## [2.0.0]
 
 ### 2025-08-22

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,7 +46,7 @@ In your app-level gradle file, import the OSBarcodeLib library like so:
 
 ```gradle
 dependencies {
-    implementation("com.github.outsystems:osbarcode-android:2.0.0@aar")
+    implementation("com.github.outsystems:osbarcode-android:2.0.1@aar")
 }
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,5 +7,5 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.ionic.libs</groupId>
     <artifactId>ionbarcode-android</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
 </project>

--- a/src/main/kotlin/com/outsystems/plugins/barcode/view/OSBARCScannerActivity.kt
+++ b/src/main/kotlin/com/outsystems/plugins/barcode/view/OSBARCScannerActivity.kt
@@ -135,7 +135,7 @@ import kotlin.math.roundToInt
  * implements the ImageAnalysis.Analyzer interface.
  */
 class OSBARCScannerActivity : ComponentActivity() {
-    private lateinit var camera: Camera
+    private var camera: Camera? = null
     private lateinit var selector: CameraSelector
     private var permissionRequestCount = 0
     private var showDialog by mutableStateOf(false)
@@ -232,6 +232,7 @@ class OSBARCScannerActivity : ComponentActivity() {
         val lifecycleOwner = LocalLifecycleOwner.current
         val context = LocalContext.current
         var permissionGiven by remember { mutableStateOf(true) }
+        var uiState by remember { mutableStateOf(OSBARCScannerUiState.DEFAULT) }
 
         // permissions
         val requestPermissionLauncher = rememberLauncherForActivityResult(
@@ -316,7 +317,13 @@ class OSBARCScannerActivity : ComponentActivity() {
                             selector,
                             preview,
                             imageAnalysis
-                        )
+                        ).also {
+                            uiState = OSBARCScannerUiState(
+                                hasFlashUnit = it.cameraInfo.hasFlashUnit(),
+                                minZoomRatio = it.cameraInfo.zoomState.value?.minZoomRatio ?: 1f,
+                                maxZoomRatio = it.cameraInfo.zoomState.value?.maxZoomRatio ?: 1f
+                            )
+                        }
                     } catch (e: Exception) {
                         e.message?.let { Log.e(LOG_TAG, it) }
                         setResult(OSBARCError.SCANNING_GENERAL_ERROR.code)
@@ -327,7 +334,7 @@ class OSBARCScannerActivity : ComponentActivity() {
                 modifier = Modifier.fillMaxSize()
             )
 
-            ScanScreenUI(parameters, windowSizeClass)
+            ScanScreenUI(parameters, windowSizeClass, uiState)
 
         }
     }
@@ -337,9 +344,14 @@ class OSBARCScannerActivity : ComponentActivity() {
      * should be rendered: portrait or landscape
      * @param parameters the scan parameters
      * @param windowSizeClass WindowSizeClass object to determine device type - phone or tablet
+     * @param uiState structure containing the state of the screen
      */
     @Composable
-    fun ScanScreenUI(parameters: OSBARCScanParameters, windowSizeClass: WindowSizeClass) {
+    fun ScanScreenUI(
+        parameters: OSBARCScanParameters,
+        windowSizeClass: WindowSizeClass,
+        uiState: OSBARCScannerUiState
+    ) {
         // actual UI on top of the camera stream
         val configuration = LocalConfiguration.current
         val windowMetrics =
@@ -356,19 +368,19 @@ class OSBARCScannerActivity : ComponentActivity() {
             // determine if device is phone or tablet
             val isPhone = windowSizeClass.widthSizeClass == WindowWidthSizeClass.Compact
             if (isPhone) {
-                ScanScreenUIPortrait(parameters, screenWidth, ScannerBorderPadding, true)
+                ScanScreenUIPortrait(parameters, screenWidth, ScannerBorderPadding, true, uiState = uiState)
             }
             else {
-                ScanScreenUILandscape(parameters, (screenWidth / 2), ScannerBorderPadding, TextToRectPadding, isPhone = false, isPortrait = true)
+                ScanScreenUILandscape(parameters, (screenWidth / 2), ScannerBorderPadding, TextToRectPadding, isPhone = false, isPortrait = true, uiState = uiState)
             }
         }
         else {
             // determine if device is phone or tablet
             val isPhone = windowSizeClass.heightSizeClass == WindowHeightSizeClass.Compact
             if (isPhone) {
-                ScanScreenUILandscape(parameters, screenHeight, ScannerBorderPadding, TextToRectPadding, isPhone = true, isPortrait = false)
+                ScanScreenUILandscape(parameters, screenHeight, ScannerBorderPadding, TextToRectPadding, isPhone = true, isPortrait = false, uiState = uiState)
             } else {
-                ScanScreenUILandscape(parameters, screenHeight / 2, ScannerBorderPadding, TextToRectPadding, isPhone = false, isPortrait = false)
+                ScanScreenUILandscape(parameters, screenHeight / 2, ScannerBorderPadding, TextToRectPadding, isPhone = false, isPortrait = false, uiState = uiState)
             }
         }
     }
@@ -498,12 +510,14 @@ class OSBARCScannerActivity : ComponentActivity() {
      * @param parameters the scan parameters
      * @param screenHeight the screen height
      * @param borderPadding the value for the border padding
+     * @param uiState structure containing the state of the screen
      */
     @Composable
     fun ScanScreenUIPortrait(parameters: OSBARCScanParameters,
                              screenHeight: Dp,
                              borderPadding: Dp,
-                             isPhone: Boolean) {
+                             isPhone: Boolean,
+                             uiState: OSBARCScannerUiState) {
         Column(
             modifier = Modifier
                 .fillMaxSize(),
@@ -554,7 +568,7 @@ class OSBARCScannerActivity : ComponentActivity() {
                     .weight(1f, fill = true)
                     .safeDrawingPadding(),
             ) {
-                val showTorch = camera.cameraInfo.hasFlashUnit()
+                val showTorch = uiState.hasFlashUnit
                 val showScan = parameters.scanButton
 
                 Column(
@@ -564,7 +578,7 @@ class OSBARCScannerActivity : ComponentActivity() {
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {
 
-                    ZoomButtons()
+                    ZoomButtons(uiState)
 
                     // scan button to turn on scanning when used
                     if (showScan) {
@@ -595,6 +609,7 @@ class OSBARCScannerActivity : ComponentActivity() {
      * @param parameters the scan parameters
      * @param screenHeight the screen height
      * @param borderPadding the value for the border padding
+     * @param uiState structure containing the state of the screen
      */
     @Composable
     fun ScanScreenUILandscape(parameters: OSBARCScanParameters,
@@ -602,7 +617,8 @@ class OSBARCScannerActivity : ComponentActivity() {
                               borderPadding: Dp,
                               textToRectPadding: Dp,
                               isPhone: Boolean,
-                              isPortrait: Boolean) {
+                              isPortrait: Boolean,
+                              uiState: OSBARCScannerUiState) {
         var rightButtonsWidth by remember { mutableStateOf(0.dp) }
         val density = LocalDensity.current
 
@@ -678,7 +694,7 @@ class OSBARCScannerActivity : ComponentActivity() {
                     verticalArrangement = Arrangement.Center,
                     horizontalAlignment = Alignment.End
                 ) {
-                    val showTorch = camera.cameraInfo.hasFlashUnit()
+                    val showTorch = uiState.hasFlashUnit
                     val showScan = parameters.scanButton
 
                     // flashlight button
@@ -690,7 +706,7 @@ class OSBARCScannerActivity : ComponentActivity() {
                         Spacer(modifier = Modifier.height(16.dp))
                     }
 
-                    ZoomButtons()
+                    ZoomButtons(uiState)
 
                     // scan button to turn on scanning when used
                     if (showScan) {
@@ -742,7 +758,7 @@ class OSBARCScannerActivity : ComponentActivity() {
             modifier = modifier
                 .clickable {
                     try {
-                        camera.cameraControl.enableTorch(!isFlashlightOn)
+                        camera?.cameraControl?.enableTorch(!isFlashlightOn)
                         isFlashlightOn = !isFlashlightOn
                     } catch (e: Exception) {
                         e.message?.let { Log.e(LOG_TAG, it) }
@@ -807,12 +823,13 @@ class OSBARCScannerActivity : ComponentActivity() {
 
     /**
      * Composable function, responsible for building the zoom buttons on the UI.
+     * @param uiState structure containing the state of the screen
      */
     @Composable
-    fun ZoomButtons() {
-        val minZoomRatio = camera.cameraInfo.zoomState.value?.minZoomRatio ?: 1f
+    fun ZoomButtons(uiState: OSBARCScannerUiState) {
+        val minZoomRatio = uiState.minZoomRatio
         val roundedRatio = (minZoomRatio * 10).roundToInt() / 10f
-        val maxZoomRatio = camera.cameraInfo.zoomState.value?.maxZoomRatio ?: 1f
+        val maxZoomRatio = uiState.maxZoomRatio
         var selectedButton by remember { mutableStateOf(2) }
 
         Row(
@@ -832,7 +849,7 @@ class OSBARCScannerActivity : ComponentActivity() {
                     "$roundedRatio${getZoomButtonSuffix(selectedButton, 1)}",
                     onClick = {
                         selectedButton = 1
-                        camera.cameraControl.setZoomRatio(minZoomRatio)
+                        camera?.cameraControl?.setZoomRatio(minZoomRatio)
                     }
                 )
             }
@@ -851,7 +868,7 @@ class OSBARCScannerActivity : ComponentActivity() {
                     "1${getZoomButtonSuffix(selectedButton, 2)}",
                     onClick = {
                         selectedButton = 2
-                        camera.cameraControl.setZoomRatio(1f)
+                        camera?.cameraControl?.setZoomRatio(1f)
                     }
                 )
             }
@@ -866,7 +883,7 @@ class OSBARCScannerActivity : ComponentActivity() {
                     "2${getZoomButtonSuffix(selectedButton, 3)}",
                     onClick = {
                         selectedButton = 3
-                        camera.cameraControl.setZoomRatio(2f)
+                        camera?.cameraControl?.setZoomRatio(2f)
                     }
                 )
             }

--- a/src/main/kotlin/com/outsystems/plugins/barcode/view/OSBARCScannerUiState.kt
+++ b/src/main/kotlin/com/outsystems/plugins/barcode/view/OSBARCScannerUiState.kt
@@ -1,0 +1,15 @@
+package com.outsystems.plugins.barcode.view
+
+data class OSBARCScannerUiState(
+    val hasFlashUnit: Boolean,
+    val minZoomRatio: Float,
+    val maxZoomRatio: Float
+) {
+    companion object {
+        val DEFAULT = OSBARCScannerUiState(
+            hasFlashUnit = false,
+            minZoomRatio = 1f,
+            maxZoomRatio = 1f
+        )
+    }
+}


### PR DESCRIPTION
## Description

Crash

```
kotlin.UninitializedPropertyAccessException: lateinit property camera has not been initialized
	at yxroq.lmgyo.jsqbx(OSBARCScannerActivity.kt:554)
```

This PR fixes the crash by:

1. Making the variable nullable instead of `lateinit`
2. Have null checks before accessing it to make changes
3. For read properties like flash and min/max zoom, hoisted them out of their composable functions to a single UI state (as recommended from [Jetpack Compose docs](https://developer.android.com/develop/ui/compose/state-hoisting)), that gets updated when `camera` finishes initialization.
    a. This is actually something we that could improve in this native library in general - do not rely on composable functions accessing and changing variables declared in activity, instead have better separation of concerns between the UI and UI logic - but this is not something that will be addressed in this PR.

## Context

https://outsystemsrd.atlassian.net/browse/RMET-4530

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Tests

Had to force a later initialization in the code for the crash to occur. Refer to the following test apps:

1. Initialization delayed by 2 seconds - CRASH - Try with [apk file](https://drive.google.com/file/d/1Qy4yg_KGgJo5oiuHky5lW3kqi6ZLXerA/view?usp=sharing) and/or [source code](https://drive.google.com/file/d/1zKRO8R9FvsU1B4fTwKyEDF4QHc_zZS3W/view?usp=sharing)
2. Initialization delayed by 2 seconds but containing fix from this PR - OK, you can notice that there's a delay in the torch and zoom buttons appear, but that's from the delayed initialization I placed to test, where 2 seconds is an extreme case, but the actual scanning can still work before the buttons appear - Try with [apk file](https://drive.google.com/file/d/1WRAxi_SAkHHu3q2Odj9V2HTd3Vld1hE1/view?usp=sharing) and/or [source code](https://drive.google.com/file/d/1nHhoiBCCuFzx9jjdwQHmmz4wdiFaUfbn/view?usp=sharing) 
3. With the same exact code from this PR - OK, no crash and there shouldn't be a noticeable delay in showing the torch / zoom buttons  - Try with [apk file](https://drive.google.com/file/d/1Jf4XcVUNQn1bTYudVAtNEGOSV5FIq5ZL/view?usp=sharing) and/or [source code](https://drive.google.com/file/d/1fV2dHaXOESRfFNKIIZJL3t-XOW0e02yT/view?usp=sharing)