### PR TITLE
feat: support multiple barcode format hints

### DIFF
--- a/src/main/kotlin/com/outsystems/plugins/barcode/controller/helper/OSBARCMLKitHelper.kt
+++ b/src/main/kotlin/com/outsystems/plugins/barcode/controller/helper/OSBARCMLKitHelper.kt
@@ -15,7 +15,10 @@ import org.jetbrains.annotations.VisibleForTesting
  * to scan an image using the ML Kit library.
  * It encapsulates all the code related with the ML Kit library.
  */
-class OSBARCMLKitHelper(private val hint: OSBARCScannerHint?): OSBARCMLKitHelperInterface {
+class OSBARCMLKitHelper(private val hints: List<OSBARCScannerHint>): OSBARCMLKitHelperInterface {
+    
+    constructor(hint: OSBARCScannerHint?) : this(listOfNotNull(hint))
+
     companion object {
         private const val LOG_TAG = "OSBARCMLKitHelper"
 
@@ -44,10 +47,10 @@ class OSBARCMLKitHelper(private val hint: OSBARCScannerHint?): OSBARCMLKitHelper
     }
 
     private val scanner by lazy {
+        val formats = hints.mapNotNull { it.toMLKitBarcodeFormat() }
         val options = BarcodeScannerOptions.Builder().apply {
-            val format = hint.toMLKitBarcodeFormat()
-            if (format != null) {
-                setBarcodeFormats(format)
+            if (formats.isNotEmpty()) {
+                setBarcodeFormats(formats.first(), *formats.drop(1).toIntArray())
             } else {
                 enableAllPotentialBarcodes()
             }

--- a/src/main/kotlin/com/outsystems/plugins/barcode/controller/helper/OSBARCZXingHelper.kt
+++ b/src/main/kotlin/com/outsystems/plugins/barcode/controller/helper/OSBARCZXingHelper.kt
@@ -18,18 +18,20 @@ import com.outsystems.plugins.barcode.model.OSBARCScannerHint
  * to scan an image using the ZXing library.
  * It encapsulates all the code related with the ZXing library.
  */
-class OSBARCZXingHelper(private val hint: OSBARCScannerHint?): OSBARCZXingHelperInterface {
+class OSBARCZXingHelper(private val hints: List<OSBARCScannerHint>): OSBARCZXingHelperInterface {
+
+    constructor(hint: OSBARCScannerHint?) : this(listOfNotNull(hint))
 
     companion object {
         private const val LOG_TAG = "OSBARCZXingHelper"
     }
 
     private val reader: MultiFormatReader by lazy {
-        val format = hint.toZXingBarcodeFormat()
+        val formats = hints.mapNotNull { it.toZXingBarcodeFormat() }.toSet()
         MultiFormatReader().apply {
-            if (format != null) {
+            if (formats.isNotEmpty()) {
                 setHints(
-                    mapOf(DecodeHintType.POSSIBLE_FORMATS to setOf(format))
+                    mapOf(DecodeHintType.POSSIBLE_FORMATS to formats)
                 )
             }
         }

--- a/src/main/kotlin/com/outsystems/plugins/barcode/model/OSBARCScanParameters.kt
+++ b/src/main/kotlin/com/outsystems/plugins/barcode/model/OSBARCScanParameters.kt
@@ -13,5 +13,6 @@ data class OSBARCScanParameters(
     @SerializedName("scanButton") val scanButton: Boolean,
     @SerializedName("scanText") val scanText: String,
     @SerializedName("hint") val hint: OSBARCScannerHint?,
-    @SerializedName("androidScanningLibrary") val androidScanningLibrary: String?
+    @SerializedName("androidScanningLibrary") val androidScanningLibrary: String?,
+    @SerializedName("hints") val hints: List<OSBARCScannerHint>? = null
 ) : Serializable

--- a/src/main/kotlin/com/outsystems/plugins/barcode/view/OSBARCScannerActivity.kt
+++ b/src/main/kotlin/com/outsystems/plugins/barcode/view/OSBARCScannerActivity.kt
@@ -102,6 +102,7 @@ import com.outsystems.plugins.barcode.controller.helper.OSBARCZXingHelper
 import com.outsystems.plugins.barcode.model.OSBARCError
 import com.outsystems.plugins.barcode.model.OSBARCScanParameters
 import com.outsystems.plugins.barcode.model.OSBARCScanResult
+import com.outsystems.plugins.barcode.model.OSBARCScannerHint
 import com.outsystems.plugins.barcode.view.ui.theme.ActionButtonsDistance
 import com.outsystems.plugins.barcode.view.ui.theme.BarcodeScannerTheme
 import com.outsystems.plugins.barcode.view.ui.theme.ButtonsBackgroundGray
@@ -182,11 +183,15 @@ class OSBARCScannerActivity : ComponentActivity() {
             .requireLensFacing(if (parameters.cameraDirection == CAM_DIRECTION_FRONT) CameraSelector.LENS_FACING_FRONT else CameraSelector.LENS_FACING_BACK)
             .build()
 
+        val rawHints = parameters.hints?.takeIf { it.isNotEmpty() } ?: listOfNotNull(parameters.hint)
+        // UNKNOWN is the JS-side ALL sentinel; its presence forces scan-all (empty list).
+        val hints = if (rawHints.any { it == OSBARCScannerHint.UNKNOWN }) emptyList() else rawHints
+
         barcodeAnalyzer = OSBARCBarcodeAnalyzer(
             OSBARCScanLibraryFactory.createScanLibraryWrapper(
                 parameters.androidScanningLibrary ?: "",
-                OSBARCZXingHelper(parameters.hint),
-                OSBARCMLKitHelper(parameters.hint)
+                OSBARCZXingHelper(hints),
+                OSBARCMLKitHelper(hints)
             ),
             OSBARCImageHelper(),
             { result ->


### PR DESCRIPTION
Adds `hints: List<OSBARCScannerHint>?` to `OSBARCScanParameters` as an additive companion to the existing single `hint`. When non-empty, `hints` takes precedence and pre-filters the decoder (MLKit `setBarcodeFormats` / ZXing `POSSIBLE_FORMATS`) to that set.

`UNKNOWN` anywhere in the list short-circuits to scan-all, matching the "ALL" sentinel behavior of single-hint mode.

Backward compatible: existing single-hint constructors retained on helpers; positional callers of `OSBARCScanParameters` unaffected.