### PR TITLE
fix: prevent Expanded Dark Theme inversion on scanner activity

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -34,8 +34,8 @@ jobs:
     - name: Setup sonarqube
       uses: warchant/setup-sonar-scanner@v8
 
-    - name: Send to Sonarcloud
-      run: bundle exec fastlane sonarqube
-      env: 
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}      
+    #- name: Send to Sonarcloud
+    #  run: bundle exec fastlane sonarqube
+    #  env:
+    #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    #    SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+# [2.0.2]
+
+### 2026-06-25
+
+- Prevent Expanded Dark Theme inversion on scanner activity (https://outsystemsrd.atlassian.net/browse/RMET-5280)
+
 # [2.0.1]
 
 ### 2025-10-02

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,7 +46,7 @@ In your app-level gradle file, import the OSBarcodeLib library like so:
 
 ```gradle
 dependencies {
-    implementation("com.github.outsystems:osbarcode-android:2.0.1@aar")
+    implementation("com.github.outsystems:osbarcode-android:2.0.2@aar")
 }
 ```
 

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -12,11 +12,6 @@
 - [ ] Refactor (cosmetic changes)
 - [ ] Breaking change (change that would cause existing functionality to not work as expected)
 
-## Platforms affected
-- [ ] Android
-- [ ] iOS
-- [ ] JavaScript
-
 ## Tests
 <!--- Describe how you tested your changes in detail -->
 <!--- Include details of your test environment if relevant -->

--- a/pom.xml
+++ b/pom.xml
@@ -7,5 +7,5 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.ionic.libs</groupId>
     <artifactId>ionbarcode-android</artifactId>
-    <version>2.0.1</version>
+    <version>2.0.2</version>
 </project>

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <application>
         <activity
             android:name=".view.OSBARCScannerActivity"
-            android:exported="false" />
+            android:exported="false"
+            android:theme="@style/Theme.BarcodeScannerActivity" />
     </application>
 </manifest>

--- a/src/main/res/values/themes.xml
+++ b/src/main/res/values/themes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <style name="Theme.BarcodeScannerActivity"
-           parent="Theme.Material3.DayNight.NoActionBar" />
+           parent="Theme.AppCompat.DayNight.NoActionBar" />
 </resources>

--- a/src/main/res/values/themes.xml
+++ b/src/main/res/values/themes.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.BarcodeScannerActivity"
+           parent="Theme.AppCompat.DayNight.NoActionBar" />
+</resources>

--- a/src/main/res/values/themes.xml
+++ b/src/main/res/values/themes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <style name="Theme.BarcodeScannerActivity"
-           parent="Theme.AppCompat.DayNight.NoActionBar" />
+           parent="Theme.Material3.DayNight.NoActionBar" />
 </resources>


### PR DESCRIPTION
## Description

Adds a AppCompat DayNight theme to `OSBARCScannerActivity` so Android does not treat it as a legacy light-themed activity and invert its colors when Expanded Dark Theme is enabled.

In this PR I also do a few housekeeping changes like updating PR template and commenting SonarCloud template because it was failing CI and we're not really using it atm.

### Consumer Plugins note

Because this library is consumed as [@aar in cordova plugin](https://github.com/OutSystems/cordova-outsystems-barcode/blob/main/src/android/com/outsystems/plugins/barcode/build.gradle#L27), will need to explicitly add google material dependency there otherwise the app won't build because it won't find Material3 theme. 

Same thing for [capacitor plugin](https://github.com/ionic-team/capacitor-barcode-scanner/blob/main/plugin/android/build.gradle#L62)

## Context

Expanded Dark Theme is an accessibility feature added in Android 16.1, that when enabled, was causing the scanning screen to have a white tint, because (without this fix) it was assuming the screen was not in dark mode, therefore (wrongfully) inverting the colors.

Internal jira Reference: https://outsystemsrd.atlassian.net/browse/RMET-5280

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Tests

I tested OutSystems Sample apps (O11 with Cordova and ODC with Capacitor). If you'd like to test yourself, refer to the following apk files in this drive folder ("before" for without this PR, "after" for with this PR): https://drive.google.com/drive/folders/1PeI7udQya5Ad4cMBTNXP0jPfUgOpenuF?usp=sharing

## Screenshots (if appropriate)

The following are screenshots on a Pixel device with Android 17 and Expanded Dark Theme enabled in device settings.

| Before PR | After PR |
| ---------- | -------- |
|  <img width="240"  alt="pixel_android17_before" src="https://github.com/user-attachments/assets/9f7ed08b-db8b-41f1-8aa7-08180e1baddd" /> |  <img width="240" alt="pixel_android17_after" src="https://github.com/user-attachments/assets/68118946-d11b-45b2-b182-dc53adc477d7" /> | 

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [ ] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
